### PR TITLE
SLING-10601 - Add a launcher module to the project archetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-archetype-parent</artifactId>
-        <version>6</version>
+        <version>7</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Use the latest sling-archetype-parent to benefit from SLING-10607