### PR TITLE
SLING-11922 - Create a fully expanded feature model when generating the archetype

### DIFF
--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -16,6 +16,8 @@
  */
 
 import java.util.regex.Pattern
+import java.util.zip.ZipFile
+
 import org.apache.commons.io.FileUtils
 
 def rootDir = new File(request.getOutputDirectory() + "/" + request.getArtifactId())
@@ -40,6 +42,7 @@ def readmeNotAll = new File(rootDir, "README.NotAll.md")
 def optionAll = request.getProperties().get("optionAll")
 def optionExample = request.getProperties().get("optionExample")
 
+def starterRef = request.getProperties().get("slingStarterBaseRef")
 
 // helper methods
 
@@ -50,6 +53,37 @@ def removeModule(pomFile, moduleName) {
     pomContent = pomContent.replaceAll(pattern, "")
     pomFile.newWriter().withWriter { w ->
         w << pomContent
+    }
+}
+
+def downloadStarter(rootDir, ref) {
+    def url = new URL("https://github.com/apache/sling-org-apache-sling-starter/archive/" + ref + ".zip")
+    println("Downloading Sling Starter from ${url}")
+    def localFile = new File(rootDir, "sling-starter.zip")
+    localFile << url.getBytes()
+    def starterZip = new ZipFile(localFile)
+    def launcherDir = new File(rootDir, "launcher")
+    starterZip.entries().each { entry ->
+        println "Extracting ${entry.name}"
+        if ( entry.name.startsWith("sling-org-apache-sling-starter-master/src/main/features/") ) {
+            // remove first segment from entry.name
+            def entryName = entry.name.substring(entry.name.indexOf("/") + 1)
+            // ignore samples which are not needed (or a security risk)
+            if ( entryName.endsWith("htl_repl.json") || entryName.endsWith("starter.json") || entryName.contains("slingshot") ) {
+                return
+            }
+            // ignore test content
+            if ( entryName.contains("test") ) {
+                return
+            }
+
+            def targetFile = new File(launcherDir, entryName)
+            if(entry.isDirectory()) {
+                targetFile.mkdirs()
+            } else {
+                targetFile << starterZip.getInputStream(entry)
+            }
+        }
     }
 }
 
@@ -138,3 +172,5 @@ if(optionExample == "m") {
     }
     removeModule(rootPom, "ui.apps.example")
 }
+
+downloadStarter(rootDir, starterRef)

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -17,11 +17,12 @@
     specific language governing permissions and limitations
     under the License.
 -->
+
 <archetype-descriptor
-        xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
-        name="sling-project-archetype"
-        xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 http://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd"
+    name="sling-project-archetype"
 >
     <requiredProperties>
 <!--        <requiredProperty key="version">-->
@@ -89,6 +90,10 @@
         <requiredProperty key="optionExample">
 <!--            <defaultValue>s</defaultValue>-->
             <validationRegex>^(s|m|d)$</validationRegex>
+        </requiredProperty>
+        <!-- Git reference from the Sling Starter project use to bootstrap the launcher -->
+        <requiredProperty key="slingStarterBaseRef">
+            <defaultValue>master</defaultValue>
         </requiredProperty>
     </requiredProperties>
     <fileSets>

--- a/src/main/resources/archetype-resources/launcher/pom.xml
+++ b/src/main/resources/archetype-resources/launcher/pom.xml
@@ -29,6 +29,11 @@
         This is a Module which contains a sample feature model build, built on
         top of the Sling Starter and adding this project's artifacts.
     </description>
+
+    <properties>
+        <!-- TODO - read from starter pom -->
+        <asm.version>9.5</asm.version>
+    </properties>
     <build>
         <plugins>
             <plugin>
@@ -37,47 +42,13 @@
                 <extensions>true</extensions>
 
                 <configuration>
+                    <!-- TODO - read from starter pom -->
+                    <replacePropertyVariables>asm.version,jackrabbit.version,groovy.version,oak.version,slf4j.version,composum.nodes.version,jackson.version</replacePropertyVariables>
                     <skipAddFeatureDependencies>true</skipAddFeatureDependencies>
-                    <framework>
-                        <groupId>org.apache.felix</groupId>
-                        <artifactId>org.apache.felix.framework</artifactId>
-                        <version>\${org.apache.felix.framework.version}</version>
-                    </framework>
-
-                    <!--
-                        Prepares a feature model aggregate that takes the following features from
-                        the Sling Starter:
-                        - nosample_base - the base Sling Starter
-                        - oak_persistence_sns - SegmentNodeStore persistence for Oak
-                        - composum - The Composum Nodes administration tool
-
-                        Notably missing are the slingshot and starter samples
-                     -->
                     <aggregates>
                         <aggregate>
                             <classifier>app</classifier>
                             <filesInclude>*.json</filesInclude>
-                            <includeArtifact>
-                                <groupId>org.apache.sling</groupId>
-                                <artifactId>org.apache.sling.starter</artifactId>
-                                <classifier>nosample_base</classifier>
-                                <version>\${sling.starter.version}</version>
-                                <type>slingosgifeature</type>
-                            </includeArtifact>
-                            <includeArtifact>
-                                <groupId>org.apache.sling</groupId>
-                                <artifactId>org.apache.sling.starter</artifactId>
-                                <classifier>oak_persistence_sns</classifier>
-                                <version>\${sling.starter.version}</version>
-                                <type>slingosgifeature</type>
-                            </includeArtifact>
-                            <includeArtifact>
-                                <groupId>org.apache.sling</groupId>
-                                <artifactId>org.apache.sling.starter</artifactId>
-                                <classifier>composum</classifier>
-                                <version>\${sling.starter.version}</version>
-                                <type>slingosgifeature</type>
-                            </includeArtifact>
                         </aggregate>
                     </aggregates>
                     <scans>

--- a/src/test/resources/projects/all/archetype.properties
+++ b/src/test/resources/projects/all/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=y
 optionExample=s
+slingStarterBaseRef=master

--- a/src/test/resources/projects/allDeleted/archetype.properties
+++ b/src/test/resources/projects/allDeleted/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=y
 optionExample=d
+slingStarterBaseRef=master

--- a/src/test/resources/projects/allMerged/archetype.properties
+++ b/src/test/resources/projects/allMerged/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=y
 optionExample=m
+slingStarterBaseRef=master

--- a/src/test/resources/projects/notAll/archetype.properties
+++ b/src/test/resources/projects/notAll/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=n
 optionExample=s
+slingStarterBaseRef=master

--- a/src/test/resources/projects/notAllDeleted/archetype.properties
+++ b/src/test/resources/projects/notAllDeleted/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=n
 optionExample=d
+slingStarterBaseRef=master

--- a/src/test/resources/projects/notAllMerged/archetype.properties
+++ b/src/test/resources/projects/notAllMerged/archetype.properties
@@ -33,3 +33,4 @@ slingHostName=localhost
 slingPort=8080
 optionAll=n
 optionExample=m
+slingStarterBaseRef=master


### PR DESCRIPTION
TODO:

- [ ] Move over all feature file copied from the Sling Starter under `src/main/features/platform`
- [ ] Create the project specific files under `src/main/features/project`
- [ ] Use the project's short name for the naming of the initial feature
- [ ] Copy over needed properties from the Starter pom.xml, start with https://github.com/apache/sling-org-apache-sling-starter/blob/705420630579652acefe71bb5bdb6229f58ef30a/pom.xml#L97 and look up the properties
- [ ] Ensure that ITs pass
- [ ] Consider allowing a tag to be specified
- [ ] Consider allowing a local git zip file to be used